### PR TITLE
Add contact page

### DIFF
--- a/catalystbook/_toc.yml
+++ b/catalystbook/_toc.yml
@@ -4,8 +4,8 @@
 format: jb-book
 root: index
 chapters:
-  - file: content/community-partnership
-  - file: content/team  
+#   - file: content/community-partnership
+#   - file: content/team
   - file: content/contact
   - file: blog/2024-04-hub-champion-training
   - file: privacy

--- a/catalystbook/content/contact.md
+++ b/catalystbook/content/contact.md
@@ -6,7 +6,7 @@ For general enquiries, please send us an email at [catalyst-project-core-team@go
 
 ## Becoming a Community Partner
 
-If you’re interested in becoming a [Community Partner](community-partnership.md) and receiving access to cloud infrastructure services as well as accompanying training and support, please complete the {ref}`application form<register>` below. Information to help you complete this application form can be found in the Community Partnerships page. After submitting your application, you can expect to receive more information within five business days. 
+If you’re interested in becoming a Community Partner and receiving access to cloud infrastructure services as well as accompanying training and support, please complete the {ref}`application form<register>` below. Information to help you complete this application form can be found in the Community Partnerships page. After submitting your application, you can expect to receive more information within five business days. 
 
 Please note that the closing date for applications for the initial phase of the Catalyst Project is **30 April 2024**. However, we’re still interested in hearing from you after this date as there may be additional opportunities to work together as the project evolves.
 
@@ -16,7 +16,7 @@ We are currently accepting applications from organisations located in Africa and
 
 Active Community Leaders and Champions can contact Catalyst Project Programme Manager Tajuddeen Gwadabe directly at [tajuddeen@we-are-ols.org](mailto:tajuddeen@we-are-ols.org).
 
-You can find contact details for additional Core Team personnel on our [Team page](team.md). 
+<!-- You can find contact details for additional Core Team personnel on our [Team page](team.md).  -->
 
 If you are interested in accessing cloud infrastructure after the project ends, please contact 2i2c ([partnerships@2i2c.org](mailto:partnerships@2i2c.org)) to find out more about pricing. Throughout the duration of the Catalyst Project, we are monitoring Community Partner usage in order to support communities in making informed decisions about their needs.
 


### PR DESCRIPTION
This omits references to community partnership and team pages for now.