### PR TITLE
Rename git submodule

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -61,9 +61,6 @@ jobs:
         jupyter-book build .
       working-directory: ./catalystbook 
 
-    # ls
-    - run: ls catalystbook/hub-activity
-
     # Upload the book's HTML as an artifact
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "catalystbook/hub-activity"]
-	path = catalystbook/hub-activity
+	path = catalystbook/01-hub-activity/
 	url = https://github.com/czi-catalystproject/hub-activity.git

--- a/catalystbook/current-community-partners.md
+++ b/catalystbook/current-community-partners.md
@@ -136,5 +136,5 @@ Medellín, Colombia
 ::::
 
 ```{raw} html
-:file: a-hub-activity/activity.html
+:file: 01-hub-activity/activity.html
 ```

--- a/catalystbook/current-community-partners.md
+++ b/catalystbook/current-community-partners.md
@@ -136,5 +136,5 @@ Medellín, Colombia
 ::::
 
 ```{raw} html
-:file: hub-activity/activity.html
+:file: a-hub-activity/activity.html
 ```


### PR DESCRIPTION
`jupyter-book build` executes notebooks in alphanumeric order - we want` hub-activity` to execute before `current-community-partners`.

